### PR TITLE
docs: rewrite README and usage guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,110 @@
-# MudBlazor Icons
+# MudBlazor Icons — Material Icons & Material Symbols for Blazor
 
-[![GitHub](https://img.shields.io/github/license/garderoben/mudblazor?color=%23594ae2&style=flat-square)](https://github.com/Garderoben/MudBlazor.Templates/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/MudBlazor/MudBlazor.Icons?color=%23594ae2&style=flat-square)](https://github.com/MudBlazor/MudBlazor.Icons/blob/master/LICENSE)
 [![Discord](https://img.shields.io/discord/786656789310865418?color=%237289da&label=Discord&logo=discord&logoColor=%237289da&style=flat-square)](https://discord.gg/mudblazor)
 [![Twitter](https://img.shields.io/twitter/follow/MudBlazor?color=1DA1F2&label=Twitter&logo=Twitter&style=flat-square)](https://twitter.com/MudBlazor)
 
-Welcome to the MudBlazor Icons repository. This project provides icon packs for MudBlazor, leveraging Google's Material Icons and Material Symbols.
+The official icon packs for [MudBlazor](https://mudblazor.com/), the Material Design component library for Blazor. These NuGet packages bring Google's complete **Material Icons** and **Material Symbols** collections — over 22,000 icon constants — to your Blazor app with full IntelliSense support.
 
-## Icon Packs
+```razor
+<MudIcon Icon="@MudBlazor.FontIcons.MaterialSymbols.Outlined.Rocket" />
+```
 
-### MudBlazor Material Icons
-[![NuGet version](https://img.shields.io/nuget/v/MudBlazor.FontIcons.MaterialIcons?color=ff4081&label=nuget%20version&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/)
-[![NuGet downloads](https://img.shields.io/nuget/dt/MudBlazor.FontIcons.MaterialIcons?color=ff4081&label=nuget%20downloads&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/)
+## Why use these packs?
 
-For more details on how to use the Material Icons in your MudBlazor project, please refer to the [Material Icons Usage Guide](documentation/material_icons_usage.md).
+- **Every icon, every style** — the complete Google icon collections, including thousands of icons and styles not available in MudBlazor's built-in icon set.
+- **IntelliSense instead of magic strings** — every icon is a strongly typed C# constant, so typos become build-time errors and your editor autocompletes icon names.
+- **Self-hosted fonts** — WOFF2 font files ship inside the package and are served from your app. No Google CDN calls, which means they work offline, in air-gapped environments, and without third-party requests (helpful for GDPR compliance).
+- **Trimming and AOT compatible** — safe to use with Blazor WebAssembly trimming and Native AOT.
+- **Works everywhere Blazor runs** — Blazor Server, Blazor WebAssembly, and Blazor Hybrid (.NET MAUI).
 
-### MudBlazor Material Symbols
+## Quick start
+
+1. Install a package:
+
+```bash
+dotnet add package MudBlazor.FontIcons.MaterialSymbols
+```
+
+2. Add the stylesheet next to your existing MudBlazor stylesheet (in `App.razor`, `index.html`, or your host page):
+
+```html
+<link href="_content/MudBlazor.FontIcons.MaterialSymbols/css/font.min.css" rel="stylesheet" />
+```
+
+3. Use any icon with `MudIcon` — or any other MudBlazor component that accepts an icon:
+
+```razor
+<MudIcon Icon="@MudBlazor.FontIcons.MaterialSymbols.Outlined.Database" />
+<MudIconButton Icon="@MudBlazor.FontIcons.MaterialSymbols.Rounded.Settings" />
+```
+
+That's it. See the usage guides below for aliases, font preloading, CDN options, and troubleshooting.
+
+## Choosing a pack
+
+| | [MudBlazor.FontIcons.MaterialSymbols](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/) | [MudBlazor.FontIcons.MaterialIcons](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/) |
+| :-- | :-- | :-- |
+| **Icon set** | Material Symbols — Google's current icon set, actively growing | Material Icons — the classic set, stable but no longer expanded |
+| **Styles** | Outlined, Rounded, Sharp | Filled, Outlined, Rounded, Sharp, Two-Tone |
+| **Icons per style** | 3,800+ | 2,100+ |
+| **Usage guide** | [Material Symbols guide](documentation/material_symbols_usage.md) | [Material Icons guide](documentation/material_icons_usage.md) |
+
+**Not sure which to pick?** Use **Material Symbols** — it's Google's actively maintained set and receives new icons regularly. Choose Material Icons if you need the Filled or Two-Tone styles, or want to match an existing Material Icons design. You can also install both packs side by side.
+
+## Packages
+
+### MudBlazor.FontIcons.MaterialSymbols
+
 [![NuGet version](https://img.shields.io/nuget/v/MudBlazor.FontIcons.MaterialSymbols?color=ff4081&label=nuget%20version&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/)
 [![NuGet downloads](https://img.shields.io/nuget/dt/MudBlazor.FontIcons.MaterialSymbols?color=ff4081&label=nuget%20downloads&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/)
 
-For more details on how to use the Material Symbols in your MudBlazor project, please refer to the [Material Symbols Usage Guide](documentation/material_symbols_usage.md).
+Google's Material Symbols in Outlined, Rounded, and Sharp styles. Full setup and examples in the [Material Symbols usage guide](documentation/material_symbols_usage.md).
 
-## Supported MudBlazor Versions
+### MudBlazor.FontIcons.MaterialIcons
 
-Both icon packs support the following MudBlazor and .NET versions:
+[![NuGet version](https://img.shields.io/nuget/v/MudBlazor.FontIcons.MaterialIcons?color=ff4081&label=nuget%20version&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/)
+[![NuGet downloads](https://img.shields.io/nuget/dt/MudBlazor.FontIcons.MaterialIcons?color=ff4081&label=nuget%20downloads&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/)
 
-| Package                           | MudBlazor Version       | .NET Version            |
-| :-------------------------------- | :----------------------:| :----------------------:|
-| MudBlazor.FontIcons.MaterialIcons | 7.0.0 and up  | .NET 8 and up         |
-| MudBlazor.FontIcons.MaterialSymbols| 7.0.0 and up  | .NET 8 and up         |
+Google's classic Material Icons in Filled, Outlined, Rounded, Sharp, and Two-Tone styles. Full setup and examples in the [Material Icons usage guide](documentation/material_icons_usage.md).
 
-## License
+## Compatibility
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+Both packages support:
+
+| Requirement | Version |
+| :-- | :-- |
+| MudBlazor | 7.0.0 and up |
+| .NET | 8, 9, and 10 |
+
+## FAQ
+
+### How is this different from MudBlazor's built-in icons?
+
+MudBlazor ships with a built-in set of Material SVG icons (`Icons.Material.Filled.Home` and friends). These packs complement it with the **complete** Google collections as icon fonts — including Material Symbols, which isn't part of MudBlazor core, and thousands of icons the built-in set doesn't cover. You can freely mix built-in SVG icons and font icons in the same app.
+
+### Do I need an internet connection or Google's CDN?
+
+No. The fonts are bundled in the NuGet package and served as static web assets from your own app. A Google Fonts CDN option exists if you prefer it — see the usage guides.
+
+### Can I browse the available icons?
+
+Yes — browse [Google Fonts icons](https://fonts.google.com/icons) to find an icon visually, then use the matching constant. For example, the symbol named `rocket_launch` is `MudBlazor.FontIcons.MaterialSymbols.Outlined.RocketLaunch`.
+
+### How are the packs kept up to date?
+
+Icon classes and fonts are generated automatically from Google's official icon metadata by the generator in this repository, and updated releases are published to NuGet.
 
 ## Contributing
 
-Contributions are welcome! Please see the [CONTRIBUTING](CONTRIBUTING.md) guide for more details.
+Contributions are welcome! See the [contributing guide](CONTRIBUTING.md) to get started, and the [code of conduct](CODE_OF_CONDUCT.md) for community standards.
 
-## Contact
+## Community & support
 
-For questions or support, please open an issue on this repository.
+- [MudBlazor documentation](https://mudblazor.com/)
+- [Discord server](https://discord.gg/mudblazor) — ask questions and chat with the community
+- [GitHub issues](https://github.com/MudBlazor/MudBlazor.Icons/issues) — report bugs or request features
+
+## License
+
+This project is licensed under the [MIT License](LICENSE). The Material Icons and Material Symbols fonts are created by Google and distributed under the [Apache License 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# MudBlazor Icons — Material Icons & Material Symbols for Blazor
+# MudBlazor Icons: Material Icons & Material Symbols for Blazor
 
 [![License](https://img.shields.io/github/license/MudBlazor/MudBlazor.Icons?color=%23594ae2&style=flat-square)](https://github.com/MudBlazor/MudBlazor.Icons/blob/master/LICENSE)
 [![Discord](https://img.shields.io/discord/786656789310865418?color=%237289da&label=Discord&logo=discord&logoColor=%237289da&style=flat-square)](https://discord.gg/mudblazor)
 [![Twitter](https://img.shields.io/twitter/follow/MudBlazor?color=1DA1F2&label=Twitter&logo=Twitter&style=flat-square)](https://twitter.com/MudBlazor)
 
-The official icon packs for [MudBlazor](https://mudblazor.com/), the Material Design component library for Blazor. These NuGet packages bring Google's complete **Material Icons** and **Material Symbols** collections — over 22,000 icon constants — to your Blazor app with full IntelliSense support.
+Every Google Material icon, ready for [MudBlazor](https://mudblazor.com/). Two official NuGet packages cover the complete Material Icons and Material Symbols collections, over 22,000 icons in total, each one a strongly typed C# constant.
 
 ```razor
 <MudIcon Icon="@MudBlazor.FontIcons.MaterialSymbols.Outlined.Rocket" />
 ```
 
-## Why use these packs?
+## Why these packs?
 
-- **Every icon, every style** — the complete Google icon collections, including thousands of icons and styles not available in MudBlazor's built-in icon set.
-- **IntelliSense instead of magic strings** — every icon is a strongly typed C# constant, so typos become build-time errors and your editor autocompletes icon names.
-- **Self-hosted fonts** — WOFF2 font files ship inside the package and are served from your app. No Google CDN calls, which means they work offline, in air-gapped environments, and without third-party requests (helpful for GDPR compliance).
-- **Trimming and AOT compatible** — safe to use with Blazor WebAssembly trimming and Native AOT.
-- **Works everywhere Blazor runs** — Blazor Server, Blazor WebAssembly, and Blazor Hybrid (.NET MAUI).
+- **Every icon, every style.** Thousands of icons MudBlazor's built-in set doesn't include, plus the entire Material Symbols collection.
+- **IntelliSense, not magic strings.** Your editor autocompletes icon names, and typos become build errors.
+- **Self-hosted fonts.** No Google CDN, no third-party requests. Works offline and in air-gapped environments.
+- **Trimming and AOT compatible.** Safe for Blazor WebAssembly trimming and Native AOT.
+- **Runs everywhere Blazor does.** Server, WebAssembly, and Hybrid (.NET MAUI).
 
 ## Quick start
 
@@ -26,85 +26,60 @@ The official icon packs for [MudBlazor](https://mudblazor.com/), the Material De
 dotnet add package MudBlazor.FontIcons.MaterialSymbols
 ```
 
-2. Add the stylesheet next to your existing MudBlazor stylesheet (in `App.razor`, `index.html`, or your host page):
+2. Add the stylesheet next to your MudBlazor stylesheet (in `App.razor`, `index.html`, or your host page):
 
 ```html
 <link href="_content/MudBlazor.FontIcons.MaterialSymbols/css/font.min.css" rel="stylesheet" />
 ```
 
-3. Use any icon with `MudIcon` — or any other MudBlazor component that accepts an icon:
+3. Use any icon, anywhere MudBlazor accepts one:
 
 ```razor
 <MudIcon Icon="@MudBlazor.FontIcons.MaterialSymbols.Outlined.Database" />
 <MudIconButton Icon="@MudBlazor.FontIcons.MaterialSymbols.Rounded.Settings" />
 ```
 
-That's it. See the usage guides below for aliases, font preloading, CDN options, and troubleshooting.
+That's it. The usage guides cover aliases, font preloading, CDN options, and troubleshooting.
 
 ## Choosing a pack
 
 | | [MudBlazor.FontIcons.MaterialSymbols](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/) | [MudBlazor.FontIcons.MaterialIcons](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/) |
 | :-- | :-- | :-- |
-| **Icon set** | Material Symbols — Google's current icon set, actively growing | Material Icons — the classic set, stable but no longer expanded |
+| **Icon set** | Material Symbols, Google's current set, still growing | Material Icons, the classic set, stable but frozen |
 | **Styles** | Outlined, Rounded, Sharp | Filled, Outlined, Rounded, Sharp, Two-Tone |
 | **Icons per style** | 3,800+ | 2,100+ |
-| **Usage guide** | [Material Symbols guide](documentation/material_symbols_usage.md) | [Material Icons guide](documentation/material_icons_usage.md) |
+| **NuGet** | [![NuGet version](https://img.shields.io/nuget/v/MudBlazor.FontIcons.MaterialSymbols?color=ff4081&label=version&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/) [![NuGet downloads](https://img.shields.io/nuget/dt/MudBlazor.FontIcons.MaterialSymbols?color=ff4081&label=downloads&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/) | [![NuGet version](https://img.shields.io/nuget/v/MudBlazor.FontIcons.MaterialIcons?color=ff4081&label=version&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/) [![NuGet downloads](https://img.shields.io/nuget/dt/MudBlazor.FontIcons.MaterialIcons?color=ff4081&label=downloads&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/) |
+| **Guide** | [Material Symbols guide](documentation/material_symbols_usage.md) | [Material Icons guide](documentation/material_icons_usage.md) |
 
-**Not sure which to pick?** Use **Material Symbols** — it's Google's actively maintained set and receives new icons regularly. Choose Material Icons if you need the Filled or Two-Tone styles, or want to match an existing Material Icons design. You can also install both packs side by side.
+Undecided? Pick **Material Symbols**. It's the set Google still adds to. Choose Material Icons if you want the Filled or Two-Tone styles, or install both; they coexist happily.
 
-## Packages
-
-### MudBlazor.FontIcons.MaterialSymbols
-
-[![NuGet version](https://img.shields.io/nuget/v/MudBlazor.FontIcons.MaterialSymbols?color=ff4081&label=nuget%20version&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/)
-[![NuGet downloads](https://img.shields.io/nuget/dt/MudBlazor.FontIcons.MaterialSymbols?color=ff4081&label=nuget%20downloads&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/)
-
-Google's Material Symbols in Outlined, Rounded, and Sharp styles. Full setup and examples in the [Material Symbols usage guide](documentation/material_symbols_usage.md).
-
-### MudBlazor.FontIcons.MaterialIcons
-
-[![NuGet version](https://img.shields.io/nuget/v/MudBlazor.FontIcons.MaterialIcons?color=ff4081&label=nuget%20version&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/)
-[![NuGet downloads](https://img.shields.io/nuget/dt/MudBlazor.FontIcons.MaterialIcons?color=ff4081&label=nuget%20downloads&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/)
-
-Google's classic Material Icons in Filled, Outlined, Rounded, Sharp, and Two-Tone styles. Full setup and examples in the [Material Icons usage guide](documentation/material_icons_usage.md).
-
-## Compatibility
-
-Both packages support:
-
-| Requirement | Version |
-| :-- | :-- |
-| MudBlazor | 7.0.0 and up |
-| .NET | 8, 9, and 10 |
+Both packages require MudBlazor 7.0.0+ and .NET 8, 9, or 10.
 
 ## FAQ
 
 ### How is this different from MudBlazor's built-in icons?
 
-MudBlazor ships with a built-in set of Material SVG icons (`Icons.Material.Filled.Home` and friends). These packs complement it with the **complete** Google collections as icon fonts — including Material Symbols, which isn't part of MudBlazor core, and thousands of icons the built-in set doesn't cover. You can freely mix built-in SVG icons and font icons in the same app.
+The built-in `Icons.Material` classes cover a curated subset of Material Icons as SVGs. These packs deliver the complete collections as icon fonts, including Material Symbols, which MudBlazor core doesn't ship at all. Mix them freely in the same app.
 
 ### Do I need an internet connection or Google's CDN?
 
-No. The fonts are bundled in the NuGet package and served as static web assets from your own app. A Google Fonts CDN option exists if you prefer it — see the usage guides.
+No. The fonts live in the NuGet package and are served by your own app. A Google Fonts CDN option exists if you prefer it; see the usage guides.
 
-### Can I browse the available icons?
+### Where do I browse the icons?
 
-Yes — browse [Google Fonts icons](https://fonts.google.com/icons) to find an icon visually, then use the matching constant. For example, the symbol named `rocket_launch` is `MudBlazor.FontIcons.MaterialSymbols.Outlined.RocketLaunch`.
+[Google Fonts](https://fonts.google.com/icons). Find `rocket_launch` there, use `Outlined.RocketLaunch` here.
 
-### How are the packs kept up to date?
+### How do the packs stay current?
 
-Icon classes and fonts are generated automatically from Google's official icon metadata by the generator in this repository, and updated releases are published to NuGet.
+A generator in this repository rebuilds the icon classes and fonts from Google's official metadata, and updates ship to NuGet.
 
-## Contributing
+## Contributing and support
 
-Contributions are welcome! See the [contributing guide](CONTRIBUTING.md) to get started, and the [code of conduct](CODE_OF_CONDUCT.md) for community standards.
-
-## Community & support
-
+- [Contributing guide](CONTRIBUTING.md) and [code of conduct](CODE_OF_CONDUCT.md)
+- [Discord](https://discord.gg/mudblazor) for questions and chat
+- [GitHub issues](https://github.com/MudBlazor/MudBlazor.Icons/issues) for bugs and feature requests
 - [MudBlazor documentation](https://mudblazor.com/)
-- [Discord server](https://discord.gg/mudblazor) — ask questions and chat with the community
-- [GitHub issues](https://github.com/MudBlazor/MudBlazor.Icons/issues) — report bugs or request features
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE). The Material Icons and Material Symbols fonts are created by Google and distributed under the [Apache License 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE).
+[MIT](LICENSE). The Material Icons and Material Symbols fonts are created by Google under the [Apache License 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE).

--- a/documentation/material_icons_usage.md
+++ b/documentation/material_icons_usage.md
@@ -3,9 +3,9 @@
 [![NuGet version](https://img.shields.io/nuget/v/MudBlazor.FontIcons.MaterialIcons?color=ff4081&label=nuget%20version&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/)
 [![NuGet downloads](https://img.shields.io/nuget/dt/MudBlazor.FontIcons.MaterialIcons?color=ff4081&label=nuget%20downloads&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/)
 
-`MudBlazor.FontIcons.MaterialIcons` is the official [MudBlazor](https://mudblazor.com/) icon pack for [Google's classic Material Icons](https://fonts.google.com/icons?icon.set=Material+Icons). It gives you **2,100+ icons in five styles** (Filled, Outlined, Rounded, Sharp, Two-Tone) as strongly typed C# constants with IntelliSense, backed by self-hosted icon fonts.
+`MudBlazor.FontIcons.MaterialIcons` puts [Google's classic Material Icons](https://fonts.google.com/icons?icon.set=Material+Icons) in your [MudBlazor](https://mudblazor.com/) app: 2,100+ icons in Filled, Outlined, Rounded, Sharp, and Two-Tone styles, each a strongly typed C# constant with IntelliSense, served by self-hosted fonts.
 
-> Looking for Google's newer, actively growing icon set? See the companion pack [MudBlazor.FontIcons.MaterialSymbols](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/).
+> Want Google's newer, still-growing icon set? See [MudBlazor.FontIcons.MaterialSymbols](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/).
 
 ## Install
 
@@ -13,27 +13,21 @@
 dotnet add package MudBlazor.FontIcons.MaterialIcons
 ```
 
-Or add it to your project file:
-
-```xml
-<PackageReference Include="MudBlazor.FontIcons.MaterialIcons" Version="*" />
-```
-
 Requires MudBlazor 7.0.0+ and .NET 8, 9, or 10.
 
 ## Add the stylesheet
 
-Add this line wherever your app loads the MudBlazor stylesheet — `App.razor` in a Blazor Web App, `wwwroot/index.html` in Blazor WebAssembly, or your host page in older Blazor Server templates:
+Add this next to your MudBlazor stylesheet (in `App.razor`, `wwwroot/index.html`, or your host page):
 
 ```html
 <link href="_content/MudBlazor.FontIcons.MaterialIcons/css/font.min.css" rel="stylesheet" />
 ```
 
-The fonts ship inside the package and are served from your own app — no CDN or internet connection required at runtime.
+The fonts ship in the package and are served by your app. No CDN, no internet required at runtime.
 
 ## Use an icon
 
-Pass any icon constant to `MudIcon`, or to any MudBlazor component with an icon parameter:
+Pass a constant to `MudIcon`, or to any MudBlazor component with an icon parameter:
 
 ```razor
 <MudIcon Icon="@MudBlazor.FontIcons.MaterialIcons.Outlined.Chat" />
@@ -43,37 +37,35 @@ Pass any icon constant to `MudIcon`, or to any MudBlazor component with an icon 
 <MudButton StartIcon="@MudBlazor.FontIcons.MaterialIcons.TwoTone.Download">Download</MudButton>
 ```
 
-To find an icon, browse [Material Icons on Google Fonts](https://fonts.google.com/icons?icon.set=Material+Icons) and convert the icon name to PascalCase: `shopping_cart` becomes `Filled.ShoppingCart`. Names that start with a digit are prefixed with an underscore: `10k` becomes `Filled._10K`.
+Browse [Material Icons on Google Fonts](https://fonts.google.com/icons?icon.set=Material+Icons) to find an icon, then PascalCase its name: `shopping_cart` becomes `Filled.ShoppingCart`. Names starting with a digit get an underscore: `10k` becomes `Filled._10K`.
 
 ## Available styles
 
-| C# class | Style | Example |
-| :-- | :-- | :-- |
-| `MaterialIcons.Filled` | Filled (the classic default) | `Filled.Home` |
-| `MaterialIcons.Outlined` | Outlined | `Outlined.Home` |
-| `MaterialIcons.Rounded` | Rounded corners | `Rounded.Home` |
-| `MaterialIcons.Sharp` | Squared corners | `Sharp.Home` |
-| `MaterialIcons.TwoTone` | Two-tone | `TwoTone.Home` |
+| C# class | Style |
+| :-- | :-- |
+| `MaterialIcons.Filled` | Filled, the classic default |
+| `MaterialIcons.Outlined` | Outlined |
+| `MaterialIcons.Rounded` | Rounded corners |
+| `MaterialIcons.Sharp` | Squared corners |
+| `MaterialIcons.TwoTone` | Two-tone |
 
-## Shorten icon names with an alias
+## Shorten names with an alias
 
-Typing the full namespace gets verbose. Add an alias to `_Imports.razor`:
+The full namespace is a mouthful. Alias it in `_Imports.razor`:
 
 ```razor
 @using MaterialIcons = MudBlazor.FontIcons.MaterialIcons
 ```
 
-Then use icons like this:
-
 ```razor
 <MudIcon Icon="@MaterialIcons.Outlined.Chat" />
 ```
 
-> **Note:** Due to a [Razor compiler limitation](https://github.com/dotnet/razor/issues/7670), `@using` aliases only work when declared in `_Imports.razor` — declaring the alias in an individual `.razor` page does not work.
+> **Note:** A [Razor compiler limitation](https://github.com/dotnet/razor/issues/7670) means aliases only work from `_Imports.razor`, not from individual `.razor` pages.
 
-## Optional: preload fonts to reduce flicker
+## Optional: preload fonts
 
-Browsers only download a font once the first icon appears, which can cause a brief flash of unstyled text. To avoid it, preload the fonts for the styles you use *before* the stylesheet link:
+Fonts download when the first icon appears, so icons can briefly flash as text. To avoid that, preload the styles you use, before the stylesheet link:
 
 ```html
 <link rel="preload"
@@ -81,34 +73,14 @@ Browsers only download a font once the first icon appears, which can cause a bri
       as="font"
       type="font/woff2"
       crossorigin>
-<link rel="preload"
-      href="_content/MudBlazor.FontIcons.MaterialIcons/font/MaterialIconsOutlined.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin>
-<link rel="preload"
-      href="_content/MudBlazor.FontIcons.MaterialIcons/font/MaterialIconsRound.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin>
-<link rel="preload"
-      href="_content/MudBlazor.FontIcons.MaterialIcons/font/MaterialIconsSharp.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin>
-<link rel="preload"
-      href="_content/MudBlazor.FontIcons.MaterialIcons/font/MaterialIconsTwoTone.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin>
 <link href="_content/MudBlazor.FontIcons.MaterialIcons/css/font.min.css" rel="stylesheet" />
 ```
 
-Only preload the styles you actually use — each preload downloads that font on every page load.
+The other styles follow the same pattern: `MaterialIconsOutlined.woff2`, `MaterialIconsRound.woff2`, `MaterialIconsSharp.woff2`, and `MaterialIconsTwoTone.woff2`. Preload only what you use; each preload is a download on every page load.
 
-## Optional: use the Google Fonts CDN instead
+## Optional: Google Fonts CDN
 
-If you prefer loading the fonts from Google's CDN rather than self-hosting, replace the package stylesheet with:
+Prefer Google's CDN? Swap the package stylesheet for:
 
 ```html
 <link href="https://fonts.googleapis.com/css2?family=Material+Icons" rel="stylesheet">
@@ -122,15 +94,13 @@ The C# constants work the same either way.
 
 ## Troubleshooting
 
-**The icon renders as text (e.g. "chat") instead of a glyph.**
-The font stylesheet isn't loaded. Check that the `<link>` tag from [Add the stylesheet](#add-the-stylesheet) is present and that the page can reach `_content/MudBlazor.FontIcons.MaterialIcons/css/font.min.css` (watch for 404s in the browser's network tab).
+**Icons render as text, like "chat".** The stylesheet isn't loading. Check the `<link>` tag and watch the browser's network tab for a 404 on `font.min.css`.
 
-**An alias like `@MaterialIcons.Outlined.X` doesn't compile.**
-Make sure the alias is declared in `_Imports.razor`, not in the page itself — see the note above.
+**An alias won't compile.** It has to live in `_Imports.razor`. See the note above.
 
 ## Related links
 
-- [MudBlazor.Icons repository](https://github.com/MudBlazor/MudBlazor.Icons) — source, issues, and contributing
-- [MudBlazor.FontIcons.MaterialSymbols](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/) — companion pack for Google's current Material Symbols set
+- [MudBlazor.Icons repository](https://github.com/MudBlazor/MudBlazor.Icons): source, issues, contributing
+- [MudBlazor.FontIcons.MaterialSymbols](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/): companion pack for Google's current Material Symbols set
 - [MudBlazor documentation](https://mudblazor.com/)
 - [Browse Material Icons on Google Fonts](https://fonts.google.com/icons?icon.set=Material+Icons)

--- a/documentation/material_icons_usage.md
+++ b/documentation/material_icons_usage.md
@@ -1,21 +1,79 @@
-# MudBlazor Material Icons
+# Material Icons for MudBlazor
+
 [![NuGet version](https://img.shields.io/nuget/v/MudBlazor.FontIcons.MaterialIcons?color=ff4081&label=nuget%20version&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/)
 [![NuGet downloads](https://img.shields.io/nuget/dt/MudBlazor.FontIcons.MaterialIcons?color=ff4081&label=nuget%20downloads&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/)
 
-## Supported MudBlazor Versions
+`MudBlazor.FontIcons.MaterialIcons` is the official [MudBlazor](https://mudblazor.com/) icon pack for [Google's classic Material Icons](https://fonts.google.com/icons?icon.set=Material+Icons). It gives you **2,100+ icons in five styles** (Filled, Outlined, Rounded, Sharp, Two-Tone) as strongly typed C# constants with IntelliSense, backed by self-hosted icon fonts.
 
-| MudBlazor.FontIcons.MaterialIcons  |    MudBlazor    |      .NET       |
-| :------------- | :-------------: | :-------------: |
-| 1.0.0  => |     7.0.0 and up      |     .NET 8 and up      |
+> Looking for Google's newer, actively growing icon set? See the companion pack [MudBlazor.FontIcons.MaterialSymbols](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/).
 
+## Install
 
-To use the icons in your MudBlazor project, you can add the following CSS link to your HTML or Razor layout:
+```bash
+dotnet add package MudBlazor.FontIcons.MaterialIcons
+```
+
+Or add it to your project file:
+
+```xml
+<PackageReference Include="MudBlazor.FontIcons.MaterialIcons" Version="*" />
+```
+
+Requires MudBlazor 7.0.0+ and .NET 8, 9, or 10.
+
+## Add the stylesheet
+
+Add this line wherever your app loads the MudBlazor stylesheet — `App.razor` in a Blazor Web App, `wwwroot/index.html` in Blazor WebAssembly, or your host page in older Blazor Server templates:
 
 ```html
 <link href="_content/MudBlazor.FontIcons.MaterialIcons/css/font.min.css" rel="stylesheet" />
 ```
 
-To reduce first-load flicker, preload the Material Symbols font files before loading the stylesheet:
+The fonts ship inside the package and are served from your own app — no CDN or internet connection required at runtime.
+
+## Use an icon
+
+Pass any icon constant to `MudIcon`, or to any MudBlazor component with an icon parameter:
+
+```razor
+<MudIcon Icon="@MudBlazor.FontIcons.MaterialIcons.Outlined.Chat" />
+
+<MudIconButton Icon="@MudBlazor.FontIcons.MaterialIcons.Filled.Settings" />
+
+<MudButton StartIcon="@MudBlazor.FontIcons.MaterialIcons.TwoTone.Download">Download</MudButton>
+```
+
+To find an icon, browse [Material Icons on Google Fonts](https://fonts.google.com/icons?icon.set=Material+Icons) and convert the icon name to PascalCase: `shopping_cart` becomes `Filled.ShoppingCart`. Names that start with a digit are prefixed with an underscore: `10k` becomes `Filled._10K`.
+
+## Available styles
+
+| C# class | Style | Example |
+| :-- | :-- | :-- |
+| `MaterialIcons.Filled` | Filled (the classic default) | `Filled.Home` |
+| `MaterialIcons.Outlined` | Outlined | `Outlined.Home` |
+| `MaterialIcons.Rounded` | Rounded corners | `Rounded.Home` |
+| `MaterialIcons.Sharp` | Squared corners | `Sharp.Home` |
+| `MaterialIcons.TwoTone` | Two-tone | `TwoTone.Home` |
+
+## Shorten icon names with an alias
+
+Typing the full namespace gets verbose. Add an alias to `_Imports.razor`:
+
+```razor
+@using MaterialIcons = MudBlazor.FontIcons.MaterialIcons
+```
+
+Then use icons like this:
+
+```razor
+<MudIcon Icon="@MaterialIcons.Outlined.Chat" />
+```
+
+> **Note:** Due to a [Razor compiler limitation](https://github.com/dotnet/razor/issues/7670), `@using` aliases only work when declared in `_Imports.razor` — declaring the alias in an individual `.razor` page does not work.
+
+## Optional: preload fonts to reduce flicker
+
+Browsers only download a font once the first icon appears, which can cause a brief flash of unstyled text. To avoid it, preload the fonts for the styles you use *before* the stylesheet link:
 
 ```html
 <link rel="preload"
@@ -46,7 +104,11 @@ To reduce first-load flicker, preload the Material Symbols font files before loa
 <link href="_content/MudBlazor.FontIcons.MaterialIcons/css/font.min.css" rel="stylesheet" />
 ```
 
-Alternatively, you can use the following CDN links:
+Only preload the styles you actually use — each preload downloads that font on every page load.
+
+## Optional: use the Google Fonts CDN instead
+
+If you prefer loading the fonts from Google's CDN rather than self-hosting, replace the package stylesheet with:
 
 ```html
 <link href="https://fonts.googleapis.com/css2?family=Material+Icons" rel="stylesheet">
@@ -56,28 +118,19 @@ Alternatively, you can use the following CDN links:
 <link href="https://fonts.googleapis.com/css2?family=Material+Icons+Two+Tone" rel="stylesheet">
 ```
 
-## Example Usage
+The C# constants work the same either way.
 
-To use an icon in your MudBlazor component, you can use the `<MudIcon>` component and specify the icon using the `Icon` parameter. For example:
+## Troubleshooting
 
-```html
-<MudIcon Icon="@MudBlazor.FontIcons.MaterialIcons.Outlined.Chat"></MudIcon>
-```
+**The icon renders as text (e.g. "chat") instead of a glyph.**
+The font stylesheet isn't loaded. Check that the `<link>` tag from [Add the stylesheet](#add-the-stylesheet) is present and that the page can reach `_content/MudBlazor.FontIcons.MaterialIcons/css/font.min.css` (watch for 404s in the browser's network tab).
 
-This will render an icon representing a chat, using the Material Icons Outlined style.
+**An alias like `@MaterialIcons.Outlined.X` doesn't compile.**
+Make sure the alias is declared in `_Imports.razor`, not in the page itself — see the note above.
 
-## Using Aliases
+## Related links
 
-If you prefer not to use the full qualifier every time, you can create an alias in `_Imports.razor` by adding the following line:
-
-```razor
-@using MaterialIcons = MudBlazor.FontIcons.MaterialIcons
-```
-
-This allows you to access the icons like this:
-
-```html
-<MudIcon Icon="@MaterialIcons.Outlined.Chat"></MudIcon>
-```
-
-**NB!** Please note that aliases do not work in normal Razor pages (https://github.com/dotnet/razor/issues/7670)!
+- [MudBlazor.Icons repository](https://github.com/MudBlazor/MudBlazor.Icons) — source, issues, and contributing
+- [MudBlazor.FontIcons.MaterialSymbols](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/) — companion pack for Google's current Material Symbols set
+- [MudBlazor documentation](https://mudblazor.com/)
+- [Browse Material Icons on Google Fonts](https://fonts.google.com/icons?icon.set=Material+Icons)

--- a/documentation/material_symbols_usage.md
+++ b/documentation/material_symbols_usage.md
@@ -1,30 +1,84 @@
-# MudBlazor Material Symbols
+# Material Symbols for MudBlazor
+
 [![NuGet version](https://img.shields.io/nuget/v/MudBlazor.FontIcons.MaterialSymbols?color=ff4081&label=nuget%20version&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/)
 [![NuGet downloads](https://img.shields.io/nuget/dt/MudBlazor.FontIcons.MaterialSymbols?color=ff4081&label=nuget%20downloads&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/)
 
-## Supported MudBlazor Versions
+`MudBlazor.FontIcons.MaterialSymbols` is the official [MudBlazor](https://mudblazor.com/) icon pack for [Google's Material Symbols](https://fonts.google.com/icons) — the current, actively growing Material Design icon set. It gives you **3,800+ icons in three styles** (Outlined, Rounded, Sharp) as strongly typed C# constants with IntelliSense, backed by self-hosted icon fonts.
 
-| MudBlazor.FontIcons.MaterialSymbols  |    MudBlazor    |      .NET       |
-| :------------- | :-------------: | :-------------: |
-| 1.0.0  => |     7.0.0 and up      |     .NET 8 and up      |
+## Install
 
+```bash
+dotnet add package MudBlazor.FontIcons.MaterialSymbols
+```
 
-To use the icons in your MudBlazor project, you can add the following CSS link to your HTML or Razor layout:
+Or add it to your project file:
+
+```xml
+<PackageReference Include="MudBlazor.FontIcons.MaterialSymbols" Version="*" />
+```
+
+Requires MudBlazor 7.0.0+ and .NET 8, 9, or 10.
+
+## Add the stylesheet
+
+Add this line wherever your app loads the MudBlazor stylesheet — `App.razor` in a Blazor Web App, `wwwroot/index.html` in Blazor WebAssembly, or your host page in older Blazor Server templates:
 
 ```html
 <link href="_content/MudBlazor.FontIcons.MaterialSymbols/css/font.min.css" rel="stylesheet" />
 ```
 
-To reduce first-load flicker, preload the Material Symbols font files before loading the stylesheet:
+The fonts ship inside the package and are served from your own app — no CDN or internet connection required at runtime.
+
+## Use an icon
+
+Pass any icon constant to `MudIcon`, or to any MudBlazor component with an icon parameter:
+
+```razor
+<MudIcon Icon="@MudBlazor.FontIcons.MaterialSymbols.Outlined.Database" />
+
+<MudIconButton Icon="@MudBlazor.FontIcons.MaterialSymbols.Rounded.Settings" />
+
+<MudButton StartIcon="@MudBlazor.FontIcons.MaterialSymbols.Sharp.Download">Download</MudButton>
+```
+
+To find an icon, browse [Google Fonts icons](https://fonts.google.com/icons) and convert the icon name to PascalCase: `rocket_launch` becomes `Outlined.RocketLaunch`. Names that start with a digit are prefixed with an underscore: `10k` becomes `Outlined._10K`.
+
+## Available styles
+
+| C# class | Style | Example |
+| :-- | :-- | :-- |
+| `MaterialSymbols.Outlined` | Outlined (default Material 3 look) | `Outlined.Home` |
+| `MaterialSymbols.Rounded` | Rounded corners | `Rounded.Home` |
+| `MaterialSymbols.Sharp` | Squared corners | `Sharp.Home` |
+
+## Shorten icon names with an alias
+
+Typing the full namespace gets verbose. Add an alias to `_Imports.razor`:
+
+```razor
+@using MaterialSymbols = MudBlazor.FontIcons.MaterialSymbols
+```
+
+Then use icons like this:
+
+```razor
+<MudIcon Icon="@MaterialSymbols.Outlined.Database" />
+```
+
+> **Note:** Due to a [Razor compiler limitation](https://github.com/dotnet/razor/issues/7670), `@using` aliases only work when declared in `_Imports.razor` — declaring the alias in an individual `.razor` page does not work.
+
+## Optional: preload fonts to reduce flicker
+
+Browsers only download a font once the first icon appears, which can cause a brief flash of unstyled text. To avoid it, preload the fonts for the styles you use *before* the stylesheet link:
 
 ```html
 <link rel="preload"
-      href="_content/MudBlazor.FontIcons.MaterialSymbols/font/MaterialSymbolsRounded.woff2"
+      href="_content/MudBlazor.FontIcons.MaterialSymbols/font/MaterialSymbolsOutlined.woff2"
       as="font"
       type="font/woff2"
       crossorigin>
 <link rel="preload"
-      href="_content/MudBlazor.FontIcons.MaterialSymbols/font/MaterialSymbolsOutlined.woff2"
+      href="_content/MudBlazor.FontIcons.MaterialSymbols/font/MaterialSymbolsRounded.woff2"
       as="font"
       type="font/woff2"
       crossorigin>
@@ -36,7 +90,11 @@ To reduce first-load flicker, preload the Material Symbols font files before loa
 <link href="_content/MudBlazor.FontIcons.MaterialSymbols/css/font.min.css" rel="stylesheet" />
 ```
 
-Alternatively, you can use the following CDN links:
+Only preload the styles you actually use — each preload downloads that font on every page load.
+
+## Optional: use the Google Fonts CDN instead
+
+If you prefer loading the fonts from Google's CDN rather than self-hosting, replace the package stylesheet with:
 
 ```html
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
@@ -44,28 +102,22 @@ Alternatively, you can use the following CDN links:
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp" rel="stylesheet" />
 ```
 
-## Example Usage
+The C# constants work the same either way.
 
-To use an icon in your MudBlazor component, you can use the `<MudIcon>` component and specify the icon using the `Icon` parameter. For example:
+## Troubleshooting
 
-```html
-<MudIcon Icon="@MudBlazor.FontIcons.MaterialSymbols.Outlined.Database"></MudIcon>
-```
+**The icon renders as text (e.g. "database") instead of a glyph.**
+The font stylesheet isn't loaded. Check that the `<link>` tag from [Add the stylesheet](#add-the-stylesheet) is present and that the page can reach `_content/MudBlazor.FontIcons.MaterialSymbols/css/font.min.css` (watch for 404s in the browser's network tab).
 
-This will render an icon representing a database, using the Material Symbols Outlined style.
+**An alias like `@MaterialSymbols.Outlined.X` doesn't compile.**
+Make sure the alias is declared in `_Imports.razor`, not in the page itself — see the note above.
 
-## Using Aliases
+**An icon I found on Google Fonts is missing.**
+Google adds new symbols continuously; the package is regenerated regularly, but very recent icons may not be in the latest release yet. Open an issue on [GitHub](https://github.com/MudBlazor/MudBlazor.Icons/issues) to request a refresh.
 
-If you prefer not to use the full qualifier every time, you can create an alias in `_Imports.razor` by adding the following line:
+## Related links
 
-```razor
-@using MaterialSymbols = MudBlazor.FontIcons.MaterialSymbols
-```
-
-This allows you to access the icons like this:
-
-```html
-<MudIcon Icon="@MaterialSymbols.Outlined.Database"></MudIcon>
-```
-
-**NB!** Please note that aliases do not work in normal Razor pages (https://github.com/dotnet/razor/issues/7670)!
+- [MudBlazor.Icons repository](https://github.com/MudBlazor/MudBlazor.Icons) — source, issues, and contributing
+- [MudBlazor.FontIcons.MaterialIcons](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/) — companion pack for the classic Material Icons set (includes Filled and Two-Tone styles)
+- [MudBlazor documentation](https://mudblazor.com/)
+- [Browse Material Symbols on Google Fonts](https://fonts.google.com/icons)

--- a/documentation/material_symbols_usage.md
+++ b/documentation/material_symbols_usage.md
@@ -3,7 +3,7 @@
 [![NuGet version](https://img.shields.io/nuget/v/MudBlazor.FontIcons.MaterialSymbols?color=ff4081&label=nuget%20version&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/)
 [![NuGet downloads](https://img.shields.io/nuget/dt/MudBlazor.FontIcons.MaterialSymbols?color=ff4081&label=nuget%20downloads&logo=nuget&style=flat-square)](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialSymbols/)
 
-`MudBlazor.FontIcons.MaterialSymbols` is the official [MudBlazor](https://mudblazor.com/) icon pack for [Google's Material Symbols](https://fonts.google.com/icons) — the current, actively growing Material Design icon set. It gives you **3,800+ icons in three styles** (Outlined, Rounded, Sharp) as strongly typed C# constants with IntelliSense, backed by self-hosted icon fonts.
+`MudBlazor.FontIcons.MaterialSymbols` puts [Google's Material Symbols](https://fonts.google.com/icons) in your [MudBlazor](https://mudblazor.com/) app: 3,800+ icons in Outlined, Rounded, and Sharp styles, each a strongly typed C# constant with IntelliSense, served by self-hosted fonts.
 
 ## Install
 
@@ -11,27 +11,21 @@
 dotnet add package MudBlazor.FontIcons.MaterialSymbols
 ```
 
-Or add it to your project file:
-
-```xml
-<PackageReference Include="MudBlazor.FontIcons.MaterialSymbols" Version="*" />
-```
-
 Requires MudBlazor 7.0.0+ and .NET 8, 9, or 10.
 
 ## Add the stylesheet
 
-Add this line wherever your app loads the MudBlazor stylesheet — `App.razor` in a Blazor Web App, `wwwroot/index.html` in Blazor WebAssembly, or your host page in older Blazor Server templates:
+Add this next to your MudBlazor stylesheet (in `App.razor`, `wwwroot/index.html`, or your host page):
 
 ```html
 <link href="_content/MudBlazor.FontIcons.MaterialSymbols/css/font.min.css" rel="stylesheet" />
 ```
 
-The fonts ship inside the package and are served from your own app — no CDN or internet connection required at runtime.
+The fonts ship in the package and are served by your app. No CDN, no internet required at runtime.
 
 ## Use an icon
 
-Pass any icon constant to `MudIcon`, or to any MudBlazor component with an icon parameter:
+Pass a constant to `MudIcon`, or to any MudBlazor component with an icon parameter:
 
 ```razor
 <MudIcon Icon="@MudBlazor.FontIcons.MaterialSymbols.Outlined.Database" />
@@ -41,35 +35,33 @@ Pass any icon constant to `MudIcon`, or to any MudBlazor component with an icon 
 <MudButton StartIcon="@MudBlazor.FontIcons.MaterialSymbols.Sharp.Download">Download</MudButton>
 ```
 
-To find an icon, browse [Google Fonts icons](https://fonts.google.com/icons) and convert the icon name to PascalCase: `rocket_launch` becomes `Outlined.RocketLaunch`. Names that start with a digit are prefixed with an underscore: `10k` becomes `Outlined._10K`.
+Browse [Google Fonts](https://fonts.google.com/icons) to find an icon, then PascalCase its name: `rocket_launch` becomes `Outlined.RocketLaunch`. Names starting with a digit get an underscore: `10k` becomes `Outlined._10K`.
 
 ## Available styles
 
-| C# class | Style | Example |
-| :-- | :-- | :-- |
-| `MaterialSymbols.Outlined` | Outlined (default Material 3 look) | `Outlined.Home` |
-| `MaterialSymbols.Rounded` | Rounded corners | `Rounded.Home` |
-| `MaterialSymbols.Sharp` | Squared corners | `Sharp.Home` |
+| C# class | Style |
+| :-- | :-- |
+| `MaterialSymbols.Outlined` | Outlined, the Material 3 default |
+| `MaterialSymbols.Rounded` | Rounded corners |
+| `MaterialSymbols.Sharp` | Squared corners |
 
-## Shorten icon names with an alias
+## Shorten names with an alias
 
-Typing the full namespace gets verbose. Add an alias to `_Imports.razor`:
+The full namespace is a mouthful. Alias it in `_Imports.razor`:
 
 ```razor
 @using MaterialSymbols = MudBlazor.FontIcons.MaterialSymbols
 ```
 
-Then use icons like this:
-
 ```razor
 <MudIcon Icon="@MaterialSymbols.Outlined.Database" />
 ```
 
-> **Note:** Due to a [Razor compiler limitation](https://github.com/dotnet/razor/issues/7670), `@using` aliases only work when declared in `_Imports.razor` — declaring the alias in an individual `.razor` page does not work.
+> **Note:** A [Razor compiler limitation](https://github.com/dotnet/razor/issues/7670) means aliases only work from `_Imports.razor`, not from individual `.razor` pages.
 
-## Optional: preload fonts to reduce flicker
+## Optional: preload fonts
 
-Browsers only download a font once the first icon appears, which can cause a brief flash of unstyled text. To avoid it, preload the fonts for the styles you use *before* the stylesheet link:
+Fonts download when the first icon appears, so icons can briefly flash as text. To avoid that, preload the styles you use, before the stylesheet link:
 
 ```html
 <link rel="preload"
@@ -77,24 +69,14 @@ Browsers only download a font once the first icon appears, which can cause a bri
       as="font"
       type="font/woff2"
       crossorigin>
-<link rel="preload"
-      href="_content/MudBlazor.FontIcons.MaterialSymbols/font/MaterialSymbolsRounded.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin>
-<link rel="preload"
-      href="_content/MudBlazor.FontIcons.MaterialSymbols/font/MaterialSymbolsSharp.woff2"
-      as="font"
-      type="font/woff2"
-      crossorigin>
 <link href="_content/MudBlazor.FontIcons.MaterialSymbols/css/font.min.css" rel="stylesheet" />
 ```
 
-Only preload the styles you actually use — each preload downloads that font on every page load.
+The other styles follow the same pattern: `MaterialSymbolsRounded.woff2` and `MaterialSymbolsSharp.woff2`. Preload only what you use; each preload is a download on every page load.
 
-## Optional: use the Google Fonts CDN instead
+## Optional: Google Fonts CDN
 
-If you prefer loading the fonts from Google's CDN rather than self-hosting, replace the package stylesheet with:
+Prefer Google's CDN? Swap the package stylesheet for:
 
 ```html
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
@@ -106,18 +88,15 @@ The C# constants work the same either way.
 
 ## Troubleshooting
 
-**The icon renders as text (e.g. "database") instead of a glyph.**
-The font stylesheet isn't loaded. Check that the `<link>` tag from [Add the stylesheet](#add-the-stylesheet) is present and that the page can reach `_content/MudBlazor.FontIcons.MaterialSymbols/css/font.min.css` (watch for 404s in the browser's network tab).
+**Icons render as text, like "database".** The stylesheet isn't loading. Check the `<link>` tag and watch the browser's network tab for a 404 on `font.min.css`.
 
-**An alias like `@MaterialSymbols.Outlined.X` doesn't compile.**
-Make sure the alias is declared in `_Imports.razor`, not in the page itself — see the note above.
+**An alias won't compile.** It has to live in `_Imports.razor`. See the note above.
 
-**An icon I found on Google Fonts is missing.**
-Google adds new symbols continuously; the package is regenerated regularly, but very recent icons may not be in the latest release yet. Open an issue on [GitHub](https://github.com/MudBlazor/MudBlazor.Icons/issues) to request a refresh.
+**An icon from Google Fonts is missing.** Google adds symbols faster than releases ship. [Open an issue](https://github.com/MudBlazor/MudBlazor.Icons/issues) to request a refresh.
 
 ## Related links
 
-- [MudBlazor.Icons repository](https://github.com/MudBlazor/MudBlazor.Icons) — source, issues, and contributing
-- [MudBlazor.FontIcons.MaterialIcons](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/) — companion pack for the classic Material Icons set (includes Filled and Two-Tone styles)
+- [MudBlazor.Icons repository](https://github.com/MudBlazor/MudBlazor.Icons): source, issues, contributing
+- [MudBlazor.FontIcons.MaterialIcons](https://www.nuget.org/packages/MudBlazor.FontIcons.MaterialIcons/): companion pack for classic Material Icons, with Filled and Two-Tone styles
 - [MudBlazor documentation](https://mudblazor.com/)
 - [Browse Material Symbols on Google Fonts](https://fonts.google.com/icons)


### PR DESCRIPTION
Rewrites the README and both usage guides so a new user can go from "what is this?" to a working icon without leaving the page.

**README**
- Opens with what the packs are and why you'd want them: complete Google sets, typed constants instead of magic strings, self-hosted fonts, trimming/AOT support.
- Three-step quick start.
- A pack comparison table (with NuGet badges) and a clear recommendation: pick Material Symbols unless you need Filled or Two-Tone.
- Short FAQ covering the common questions, including how this differs from MudBlazor's built-in icons.
- Fixes the license badge, which pointed at the MudBlazor.Templates repo.

**Usage guides** (also the NuGet package READMEs, so they stand alone with absolute links)
- Reordered by task: install, stylesheet, usage, styles, aliases, optional preload/CDN, troubleshooting.
- Explains how to find an icon on Google Fonts and turn its name into the C# constant, including the digit rule (`10k` becomes `_10K`).
- Adds troubleshooting for the top gotcha: icons rendering as literal text when the stylesheet is missing.

All example constants verified against the generated classes; `dotnet pack` succeeds with the guides as package READMEs. Independent of #33 and #34.