### PR TITLE
chore: expand NuGet package descriptions and tags for discoverability

### DIFF
--- a/src/MudBlazor.FontIcons.MaterialIcons/MudBlazor.FontIcons.MaterialIcons.csproj
+++ b/src/MudBlazor.FontIcons.MaterialIcons/MudBlazor.FontIcons.MaterialIcons.csproj
@@ -21,10 +21,10 @@
     <Company>MudBlazor</Company>
     <Authors>Garderoben, Henon and Contributors</Authors>
     <Copyright>Copyright 2024 MudBlazor</Copyright>
-    <Description>Official Material Icons pack for MudBlazor.</Description>
+    <Description>Official Material Icons pack for MudBlazor. Over 2,100 Google Material Design icons in Filled, Outlined, Rounded, Sharp, and Two-Tone styles as strongly typed C# constants with IntelliSense, backed by self-hosted icon fonts — no CDN required. Trimming and AOT compatible.</Description>
     <PackageProjectUrl>https://mudblazor.com/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/MudBlazor/MudBlazor.Icons</RepositoryUrl>
-    <PackageTags>MudBlazor, Material Icons, Material, Icons, Blazor, Blazor Library</PackageTags>
+    <PackageTags>MudBlazor, Material Icons, Material Design, Icons, Icon Pack, Font Icons, Blazor, Blazor Library, Components, WebAssembly, WASM, dotnet</PackageTags>
     <RepositoryType>git</RepositoryType>
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/MudBlazor.FontIcons.MaterialIcons/MudBlazor.FontIcons.MaterialIcons.csproj
+++ b/src/MudBlazor.FontIcons.MaterialIcons/MudBlazor.FontIcons.MaterialIcons.csproj
@@ -21,7 +21,7 @@
     <Company>MudBlazor</Company>
     <Authors>Garderoben, Henon and Contributors</Authors>
     <Copyright>Copyright 2024 MudBlazor</Copyright>
-    <Description>Official Material Icons pack for MudBlazor. Over 2,100 Google Material Design icons in Filled, Outlined, Rounded, Sharp, and Two-Tone styles as strongly typed C# constants with IntelliSense, backed by self-hosted icon fonts — no CDN required. Trimming and AOT compatible.</Description>
+    <Description>Official Material Icons pack for MudBlazor. Over 2,100 Google Material Design icons in Filled, Outlined, Rounded, Sharp, and Two-Tone styles, each a strongly typed C# constant with IntelliSense. Fonts are self-hosted, so no CDN is required. Trimming and AOT compatible.</Description>
     <PackageProjectUrl>https://mudblazor.com/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/MudBlazor/MudBlazor.Icons</RepositoryUrl>
     <PackageTags>MudBlazor, Material Icons, Material Design, Icons, Icon Pack, Font Icons, Blazor, Blazor Library, Components, WebAssembly, WASM, dotnet</PackageTags>

--- a/src/MudBlazor.FontIcons.MaterialSymbols/MudBlazor.FontIcons.MaterialSymbols.csproj
+++ b/src/MudBlazor.FontIcons.MaterialSymbols/MudBlazor.FontIcons.MaterialSymbols.csproj
@@ -21,7 +21,7 @@
     <Company>MudBlazor</Company>
     <Authors>Garderoben, Henon and Contributors</Authors>
     <Copyright>Copyright 2024 MudBlazor</Copyright>
-    <Description>Official Material Symbols pack for MudBlazor. Over 3,800 Google Material Design symbols in Outlined, Rounded, and Sharp styles as strongly typed C# constants with IntelliSense, backed by self-hosted icon fonts — no CDN required. Trimming and AOT compatible.</Description>
+    <Description>Official Material Symbols pack for MudBlazor. Over 3,800 Google Material Design symbols in Outlined, Rounded, and Sharp styles, each a strongly typed C# constant with IntelliSense. Fonts are self-hosted, so no CDN is required. Trimming and AOT compatible.</Description>
     <PackageProjectUrl>https://mudblazor.com/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/MudBlazor/MudBlazor.Icons</RepositoryUrl>
     <PackageTags>MudBlazor, Material Symbols, Material Design, Material Icons, Icons, Icon Pack, Font Icons, Blazor, Blazor Library, Components, WebAssembly, WASM, dotnet</PackageTags>

--- a/src/MudBlazor.FontIcons.MaterialSymbols/MudBlazor.FontIcons.MaterialSymbols.csproj
+++ b/src/MudBlazor.FontIcons.MaterialSymbols/MudBlazor.FontIcons.MaterialSymbols.csproj
@@ -21,10 +21,10 @@
     <Company>MudBlazor</Company>
     <Authors>Garderoben, Henon and Contributors</Authors>
     <Copyright>Copyright 2024 MudBlazor</Copyright>
-    <Description>Official Material Symbols pack for MudBlazor.</Description>
+    <Description>Official Material Symbols pack for MudBlazor. Over 3,800 Google Material Design symbols in Outlined, Rounded, and Sharp styles as strongly typed C# constants with IntelliSense, backed by self-hosted icon fonts — no CDN required. Trimming and AOT compatible.</Description>
     <PackageProjectUrl>https://mudblazor.com/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/MudBlazor/MudBlazor.Icons</RepositoryUrl>
-    <PackageTags>MudBlazor, Material Symbols, Material, Symbols, Icons, Blazor, Blazor Library</PackageTags>
+    <PackageTags>MudBlazor, Material Symbols, Material Design, Material Icons, Icons, Icon Pack, Font Icons, Blazor, Blazor Library, Components, WebAssembly, WASM, dotnet</PackageTags>
     <RepositoryType>git</RepositoryType>
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
nuget.org search weights `Description` and `PackageTags` heavily, and both packages shipped one-sentence descriptions.

- Descriptions now state icon counts, styles, typed constants with IntelliSense, self-hosted fonts, and trimming/AOT support. This text also renders at the top of each nuget.org package page.
- Tags broadened with terms people actually search: `Material Design`, `Icon Pack`, `Font Icons`, `WebAssembly`, `dotnet`. The Symbols package also carries `Material Icons`, the term most people search even when Symbols is what they want.

`dotnet pack` succeeds for both packages on net8.0/net9.0/net10.0. Independent of #32 and #33.