### PR TITLE
Fix Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
       "matchUpdateTypes": [
         "patch"
       ],
-      "allowedVersions": "8.0.x",
+      "matchCurrentVersion": "8.0.x",
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true


### PR DESCRIPTION
## Summary
Renovate stopped opening PRs because `packageRules[2]` in `renovate.json` combined `matchUpdateTypes` with `allowedVersions`, which Renovate rejects (a filter cannot be combined with that matcher).

This replaces `"allowedVersions": "8.0.x"` with `"matchCurrentVersion": "8.0.x"` — a proper matcher — preserving the intent of auto-merging only 8.0.x patch updates for `Microsoft.AspNetCore.Components.Web`. The separate `allowedVersions: "<9.0.0"` rule (which has no `matchUpdateTypes`) is unaffected and still caps upgrades below .NET 9.

## Validation
`npx renovate-config-validator renovate.json` passes:
```
INFO: Config validated successfully against 1 file(s)
```

Closes #39