### PR TITLE
Run continuous CI on master pushes and pull requests

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -2,6 +2,9 @@ name: continuous
 
 on:
   push:
+    branches:
+      - master
+  pull_request:
 
 env:
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages


### PR DESCRIPTION
`continuous.yml` triggers on a bare `push:` with no `pull_request` trigger. A `push` event **never fires for a pull request opened from a fork**, so fork PRs reach review with nothing built and nothing packed.

The same trigger causes the inverse problem: bare `push:` matches every branch and every tag. This repo currently has 14 non-default branches, so every push to any of them runs a full restore/build/pack, and a release tag push runs `continuous` and `release` concurrently over the same commit.

This is one of three matching PRs closing the same gap across the org — see MudBlazor/ThemeManager#47 and the corresponding Templates PR. Of the org's active repos, MudBlazor, TryMudBlazor, and Translations already had a `pull_request` trigger; ThemeManager, Icons, and Templates did not.

## Change

```yaml
on:
  push:
    branches:
      - master
  pull_request:
```

This matches the trigger shape already used by `MudBlazor/MudBlazor` (`build-test-mudblazor.yml`) and `MudBlazor/TryMudBlazor` (`build-test-trymudblazor.yml`), both of which scope push to the default branch and leave `pull_request` unscoped.

`release.yml` and `update-material-symbols.yml` are untouched.
