### PR TITLE
Pin the .NET SDK with global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
The repo has no `global.json`, so builds use whatever SDK the machine or runner happens to provide. CI installs `10.0.x` via `actions/setup-dotnet`, but nothing pins it — local and CI builds can silently diverge, and a new SDK feature band can change behaviour with no commit to point at.

Every other active repo in the org (`MudBlazor`, `Translations`, `ThemeManager`) already pins its SDK. This closes the gap.

`rollForward: latestFeature` matches the convention in [MudBlazor/MudBlazor](https://github.com/MudBlazor/MudBlazor/blob/dev/global.json). It still accepts any `10.0.x` the runner installs — so the existing `dotnet-version: 10.0.x` in the workflows keeps working unchanged — while ruling out an unintended roll to a future major.