### PR TITLE
Add a format check to continuous CI

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -10,6 +10,28 @@ env:
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 
 jobs:
+  format-check:
+    name: format-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v6
+        with:
+          key: ${{ github.repository }}-nuget-${{ hashFiles('**/*.csproj') }}
+          path: ${{ env.NUGET_PACKAGES }}
+      - name: Restore
+        run: dotnet restore MudBlazor.IconPack.slnx
+      - uses: xt0rted/dotnet-format-problem-matcher@v1
+      - name: Check whitespace formatting
+        run: dotnet format whitespace MudBlazor.IconPack.slnx --no-restore --verify-no-changes
+      - name: Check code style
+        run: dotnet format style MudBlazor.IconPack.slnx --no-restore --verify-no-changes
+
   build-pack:
     name: build-pack
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Nothing in CI guards formatting, so whitespace and code-style drift lands unnoticed. Both the org's shared [`template-build-test.yml`](https://github.com/MudBlazor/Workflows/blob/main/.github/workflows/template-build-test.yml) and [MudBlazor/MudBlazor](https://github.com/MudBlazor/MudBlazor/blob/dev/.github/workflows/build-test-mudblazor.yml) run a `dotnet format` check; this repo runs none.

## Change

A `format-check` job in `continuous.yml`, running in parallel with `build-pack`:

```yaml
- name: Check whitespace formatting
  run: dotnet format whitespace MudBlazor.IconPack.slnx --no-restore --verify-no-changes
- name: Check code style
  run: dotnet format style MudBlazor.IconPack.slnx --no-restore --verify-no-changes
```

It includes `xt0rted/dotnet-format-problem-matcher@v1` so failures annotate the diff inline, matching what MudBlazor already does.

## Why the analyzers pass is excluded

A bare `dotnet format --verify-no-changes` fails on master today (exit 2). The whitespace and style passes are both clean — the failure comes entirely from the analyzers pass, which wants to apply **CA1515 at 17 sites** in `GoogleMaterialDesignIconsGenerator`, rewriting `public` types to `internal`.

That is a source-visibility decision, not a formatting one, and it stems from the project's `AnalysisMode=AllEnabledByDefault`. Folding it into a CI PR would mix a workflow change with a non-trivial source rewrite, so I left it out. Worth a follow-up: either apply the CA1515 fixes to the generator, or set the rule's severity in an `.editorconfig` and then widen this job to the full `dotnet format`.