### PR TITLE
Stop Renovate from updating the .NET SDK

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "config:recommended"
   ],
+  "ignoreDeps": [
+    "dotnet-sdk"
+  ],
   "packageRules": [
     {
       "matchManagers": [


### PR DESCRIPTION
Closes #44.

Pinning the SDK in #43 made Renovate treat `global.json` as a managed dependency, and it immediately opened #44 to bump `10.0.100` → `10.0.302`.

That PR is noise, and merging it would actively hurt:

- The pin uses `rollForward: latestFeature`, so the recorded version is a **floor, not an exact requirement**. CI installs `10.0.x` and already resolves the newest patch without the file ever changing — the bump buys nothing.
- Raising the floor to `10.0.302` breaks the build for any contributor whose installed SDK is an earlier 10.0 patch, for no benefit.
- It recurs on every SDK servicing release, so it is permanent background noise on the dependency dashboard.
