### PR TITLE
Open a pull request instead of pushing an unreleasable tag

### DIFF
--- a/.github/workflows/update-material-symbols.yml
+++ b/.github/workflows/update-material-symbols.yml
@@ -7,14 +7,17 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 env:
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+  UPDATE_BRANCH: chore/update-material-symbols
 
 jobs:
   update:
     name: update
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
         with:
@@ -40,14 +43,7 @@ jobs:
           else
             echo "has_font_changes=true" >> "$GITHUB_OUTPUT"
           fi
-      - name: Commit Material Symbols update
-        if: steps.changes.outputs.has_font_changes == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add src/MudBlazor.FontIcons.MaterialSymbols/
-          git commit -m "chore: update material symbols"
-      - name: Create next patch tag
+      - name: Suggest next patch version
         if: steps.changes.outputs.has_font_changes == 'true'
         id: next_tag
         shell: bash
@@ -71,13 +67,50 @@ jobs:
             next_tag="${major}.${minor}.${next_patch}"
           done
 
-          git tag "$next_tag"
           echo "tag=$next_tag" >> "$GITHUB_OUTPUT"
-      - name: Push commit and tag
+      - name: Open pull request
         if: steps.changes.outputs.has_font_changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT_TAG: ${{ steps.next_tag.outputs.tag }}
         run: |
-          git push origin "HEAD:${GITHUB_REF_NAME}"
-          git push origin "${{ steps.next_tag.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "${UPDATE_BRANCH}"
+          git add src/MudBlazor.FontIcons.MaterialSymbols/
+          git commit -m "chore: update material symbols"
+          git push --force origin "${UPDATE_BRANCH}"
+
+          # Reuse the existing pull request when a previous run left one open.
+          if [[ -n "$(gh pr list --head "${UPDATE_BRANCH}" --state open --json number --jq '.[].number')" ]]; then
+            echo "Updated the existing pull request for ${UPDATE_BRANCH}."
+            exit 0
+          fi
+
+          cat > "${RUNNER_TEMP}/pr-body.md" <<'EOF'
+          Google published new Material Symbols. This pull request was opened
+          automatically by the `update-material-symbols` workflow.
+
+          Review the regenerated fonts and constants, then merge.
+
+          **To publish, push the tag after merging:**
+
+          ```
+          git tag NEXT_TAG_PLACEHOLDER && git push origin NEXT_TAG_PLACEHOLDER
+          ```
+
+          Tagging by hand is deliberate: a tag pushed by `GITHUB_TOKEN` does not
+          start a new workflow run, so it would never trigger `release`.
+          EOF
+
+          sed -i "s/NEXT_TAG_PLACEHOLDER/${NEXT_TAG}/g" "${RUNNER_TEMP}/pr-body.md"
+
+          gh pr create \
+            --base "${GITHUB_REF_NAME}" \
+            --head "${UPDATE_BRANCH}" \
+            --title "chore: update material symbols" \
+            --body-file "${RUNNER_TEMP}/pr-body.md"
       - name: No font changes
         if: steps.changes.outputs.has_font_changes != 'true'
         run: echo "No changes in src/MudBlazor.FontIcons.MaterialSymbols/wwwroot/font/."


### PR DESCRIPTION
`update-material-symbols` commits to `master` and pushes a patch tag, expecting `release.yml` to pick it up. **It never does.** GitHub does not start a workflow run from a push made with `GITHUB_TOKEN`, so the tag just sits there.

The job reported success both times it fired, which is why this went unnoticed:

| Tag | Created | Author | `release` run | On NuGet |
|---|---|---|---|---|
| `1.4.1` | 2026-04-01 | `github-actions[bot]` | none | no |
| `1.4.2` | 2026-07-01 | `github-actions[bot]` | none | no |
| `1.5.0` | 2026-07-26 | human | success | yes |

```
$ curl -s https://api.nuget.org/v3-flatcontainer/mudblazor.fonticons.materialsymbols/index.json
["1.0.0","1.0.1","1.0.2","1.1.0","1.2.0","1.3.0","1.4.0","1.5.0"]   ← 1.4.1, 1.4.2 absent
```

Two icon refreshes were generated, committed, tagged, and silently never shipped. The next scheduled run is **2026-10-01** and would produce a third.

This will now push the regenerated files to a branch and open a pull request instead of committing to `master` and tagging.

- The font diff gets a human look and runs through CI before landing — worthwhile, since the content is pulled from Google upstream.
- The tag is pushed by a person afterwards, and a human-pushed tag **does** trigger `release`.
- The next patch version is still computed and printed in the pull request body, so there is nothing to work out by hand.

Also added `timeout-minutes: 30`, and the job now reuses an already-open pull request rather than failing when a previous run left one behind.
