### PR TITLE
Triage new issues with AutoTriage

### DIFF
--- a/.github/workflows/autotriage.yml
+++ b/.github/workflows/autotriage.yml
@@ -1,0 +1,24 @@
+name: AutoTriage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  triage:
+    if: ${{ github.repository_owner == 'MudBlazor' && github.event.sender.type != 'Bot' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: danielchalmers/AutoTriage@v4
+        with:
+          issues: ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
Runs the same AutoTriage action as `MudBlazor/MudBlazor`, on newly opened issues only.

**Why:** preventative rather than remedial — the backlog here is healthy (2 open). The value is that an arriving issue gets labelled and its missing details requested immediately, rather than waiting for someone to happen to look. Inflow is 4 per 180 days, so it costs almost nothing to run.

**Issues only**, no `pull_request_target` — 39 PRs in 180 days, **zero from external contributors** (26 bot, 13 core team), so it would fire ~26 times a half-year on Renovate PRs for no benefit.

Guards: `repository_owner == 'MudBlazor'` (skips forks) and `sender.type != 'Bot'` (skips Renovate dashboards). `GEMINI_API_KEY` is already an org secret, so no setup needed.

No `AutoTriage.prompt` — the action falls back to its default policy. Add `dry-run: "true"` to review the plan before it acts.

_Replaces #48, which became unreopenable after a bad force-push._
