### PR TITLE
Move shared MSBuild properties to Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!-- Applies to every project in the repository, including the generator. -->
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Company>MudBlazor</Company>
+    <Authors>Garderoben, Henon and Contributors</Authors>
+    <Copyright>Copyright 2026 MudBlazor</Copyright>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <AnalysisLevel>latest</AnalysisLevel>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <!--
+    Shipping icon packs only. The generator is a build-time tool that produces the icon
+    classes and fonts; it targets a single TFM and is never packed, so none of the
+    multi-targeting, trimming, or package metadata below applies to it.
+  -->
+  <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('MudBlazor.FontIcons'))">
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <!-- Icon constants are generated from Google's metadata and keep its naming (Filled._3d_rotation). -->
+    <NoWarn>CA1707;CA1708;CA1711</NoWarn>
+    <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('MudBlazor.FontIcons'))">
+    <IsPackable>true</IsPackable>
+    <PackageProjectUrl>https://mudblazor.com/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/MudBlazor/MudBlazor.Icons</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageIcon>icon.png</PackageIcon>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(MSBuildProjectName.StartsWith('MudBlazor.FontIcons'))">
+    <None Include="$(MSBuildThisFileDirectory)$(PackageIcon)">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <SupportedPlatform Include="browser" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.29" />
+  </ItemGroup>
+
+</Project>

--- a/src/GoogleMaterialDesignIconsGenerator/GoogleMaterialDesignIconsGenerator.csproj
+++ b/src/GoogleMaterialDesignIconsGenerator/GoogleMaterialDesignIconsGenerator.csproj
@@ -4,14 +4,6 @@
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-  
-  <PropertyGroup>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <AnalysisLevel>latest</AnalysisLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MudBlazor.FontIcons.MaterialIcons/MudBlazor.FontIcons.MaterialIcons.csproj
+++ b/src/MudBlazor.FontIcons.MaterialIcons/MudBlazor.FontIcons.MaterialIcons.csproj
@@ -1,64 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <NoWarn>CA1707;CA1708;CA1711</NoWarn>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <IsTrimmable>true</IsTrimmable>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-    <IsAotCompatible>true</IsAotCompatible>
-  </PropertyGroup>
-  
-  <PropertyGroup>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <AnalysisLevel>latest</AnalysisLevel>
-  </PropertyGroup>
-  
-  <PropertyGroup>
-    <IsPackable>true</IsPackable>
-    <Company>MudBlazor</Company>
-    <Authors>Garderoben, Henon and Contributors</Authors>
-    <Copyright>Copyright 2026 MudBlazor</Copyright>
     <Description>Official Material Icons pack for MudBlazor. Over 2,100 Google Material Design icons in Filled, Outlined, Rounded, Sharp, and Two-Tone styles, each a strongly typed C# constant with IntelliSense. Fonts are self-hosted, so no CDN is required. Trimming and AOT compatible.</Description>
-    <PackageProjectUrl>https://mudblazor.com/</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/MudBlazor/MudBlazor.Icons</RepositoryUrl>
     <PackageTags>MudBlazor, Material Icons, Material Design, Icons, Icon Pack, Font Icons, Blazor, Blazor Library, Components, WebAssembly, WASM, dotnet</PackageTags>
-    <RepositoryType>git</RepositoryType>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>material_icons_usage.md</PackageReadmeFile>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-  </PropertyGroup>
-  
   <ItemGroup>
-    <None Include="..\..\$(PackageIcon)">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
     <None Include="..\..\documentation\$(PackageReadmeFile)">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <SupportedPlatform Include="browser" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.29" />
   </ItemGroup>
 
 </Project>

--- a/src/MudBlazor.FontIcons.MaterialSymbols/MudBlazor.FontIcons.MaterialSymbols.csproj
+++ b/src/MudBlazor.FontIcons.MaterialSymbols/MudBlazor.FontIcons.MaterialSymbols.csproj
@@ -1,64 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <NoWarn>CA1707;CA1708;CA1711</NoWarn>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <IsTrimmable>true</IsTrimmable>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-    <IsAotCompatible>true</IsAotCompatible>
-  </PropertyGroup>
-  
-  <PropertyGroup>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <AnalysisLevel>latest</AnalysisLevel>
-  </PropertyGroup>
-  
-  <PropertyGroup>
-    <IsPackable>true</IsPackable>
-    <Company>MudBlazor</Company>
-    <Authors>Garderoben, Henon and Contributors</Authors>
-    <Copyright>Copyright 2026 MudBlazor</Copyright>
     <Description>Official Material Symbols pack for MudBlazor. Over 3,800 Google Material Design symbols in Outlined, Rounded, and Sharp styles, each a strongly typed C# constant with IntelliSense. Fonts are self-hosted, so no CDN is required. Trimming and AOT compatible.</Description>
-    <PackageProjectUrl>https://mudblazor.com/</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/MudBlazor/MudBlazor.Icons</RepositoryUrl>
     <PackageTags>MudBlazor, Material Symbols, Material Design, Material Icons, Icons, Icon Pack, Font Icons, Blazor, Blazor Library, Components, WebAssembly, WASM, dotnet</PackageTags>
-    <RepositoryType>git</RepositoryType>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>material_symbols_usage.md</PackageReadmeFile>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-  </PropertyGroup>
-  
   <ItemGroup>
-    <None Include="..\..\$(PackageIcon)">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
     <None Include="..\..\documentation\$(PackageReadmeFile)">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <SupportedPlatform Include="browser" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.29" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
`MudBlazor.FontIcons.MaterialIcons.csproj` and `MudBlazor.FontIcons.MaterialSymbols.csproj` were ~95% identical. Every shared setting — TFMs, trimming flags, analyzer config, package identity, symbol settings — was written twice, so any change had to be applied in both places and could silently drift. The copyright year going stale in both files at once was a symptom of exactly this.

New root `Directory.Build.props`, split into three tiers:

- **All projects** (including the generator): `ImplicitUsings`, `Nullable`, `Company`, `Authors`, `Copyright`, the analyzer block, and the CI `ContinuousIntegrationBuild` toggle.
- **Icon packs only**, gated on `$(MSBuildProjectName.StartsWith('MudBlazor.FontIcons'))`: multi-targeting, trimming/AOT flags, `NoWarn`, package identity, symbol settings, the `icon.png` pack item, `SupportedPlatform`, and the `Microsoft.AspNetCore.Components.Web` reference.
- **Per project**: only `Description`, `PackageTags`, `PackageReadmeFile`, and the readme pack item.

The generator is excluded from the pack-specific tier because it targets a single TFM and is never packed — inheriting `TargetFrameworks` would fight its own `TargetFramework`.