### PR TITLE
Drop unused `Microsoft.AspNetCore.Components.Web` reference

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,6 @@
         "nuget"
       ],
       "matchPackageNames": [
-        "Microsoft.AspNetCore.Components.Web",
         "Microsoft.CodeAnalysis.CSharp",
         "Spectre.Console"
       ],
@@ -20,30 +19,6 @@
         "major"
       ],
       "enabled": false
-    },
-    {
-      "matchManagers": [
-        "nuget"
-      ],
-      "matchPackageNames": [
-        "Microsoft.AspNetCore.Components.Web"
-      ],
-      "allowedVersions": "<9.0.0"
-    },
-    {
-      "matchManagers": [
-        "nuget"
-      ],
-      "matchPackageNames": [
-        "Microsoft.AspNetCore.Components.Web"
-      ],
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "matchCurrentVersion": "8.0.x",
-      "automerge": true,
-      "automergeType": "pr",
-      "platformAutomerge": true
     },
     {
       "matchManagers": [

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -53,7 +53,6 @@
       <PackagePath>\</PackagePath>
     </None>
     <SupportedPlatform Include="browser" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.29" />
   </ItemGroup>
 
 </Project>

--- a/src/MudBlazor.FontIcons.MaterialIcons/_Imports.razor
+++ b/src/MudBlazor.FontIcons.MaterialIcons/_Imports.razor
@@ -1,1 +1,0 @@
-﻿@using Microsoft.AspNetCore.Components.Web

--- a/src/MudBlazor.FontIcons.MaterialSymbols/_Imports.razor
+++ b/src/MudBlazor.FontIcons.MaterialSymbols/_Imports.razor
@@ -1,1 +1,0 @@
-﻿@using Microsoft.AspNetCore.Components.Web


### PR DESCRIPTION
Closes #52: Both packs referenced `Microsoft.AspNetCore.Components.Web` at `8.0.29` for all three TFMs, so net9 and net10 consumers took an 8.0.x dependency on a library that never used it.

- Remove the `PackageReference` from `Directory.Build.props`.
- Delete both `_Imports.razor` files (each was a single `@using Microsoft.AspNetCore.Components.Web` with no components to apply it to).
- Remove the three Renovate rules that existed only to manage this package: the `<9.0.0` version cap, the 8.0.x patch automerge, and its entry in the major-update block. The block rule stays for `Microsoft.CodeAnalysis.CSharp` and `Spectre.Console`, which the generator still uses.
- Add a comment at each `<Project Sdk="Microsoft.NET.Sdk.Razor">` explaining why the Razor SDK is here without the component reference, so the template scaffolding doesn't get restored later.

`Microsoft.NET.Sdk.Razor` stays — it provides the static web asset support that serves the fonts and CSS from `_content/`.

Both the reference and `_Imports.razor` arrived in the commit that first scaffolded the package projects, with the exact fingerprint of `dotnet new razorclasslib`. The template's sample component was deleted at the time; the scaffolding supporting it was not. No `.razor` component has ever existed in this repo, and `using System;` is the only using statement across all generated code.

It wasn't anomalous at first — the reference was `7.0.0` against `net7.0;net8.0`. The mismatch opened up when the TFMs moved to net8/9/10 while the reference stayed on the 8.0.x line, held there by the Renovate cap added to protect the net8 floor.