### PR TITLE
Add icon pack test suite

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,6 +21,24 @@
       "enabled": false
     },
     {
+      "groupName": "test dependencies",
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchFileNames": [
+        "test/**"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "digest"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
       "matchManagers": [
         "github-actions"
       ],

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -31,6 +31,25 @@ jobs:
       - name: Check code style
         run: dotnet format style MudBlazor.IconPack.slnx --no-restore --verify-no-changes
 
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v6
+        with:
+          key: ${{ github.repository }}-nuget-${{ hashFiles('**/*.csproj') }}
+          path: ${{ env.NUGET_PACKAGES }}
+      - name: Restore
+        run: dotnet restore test/MudBlazor.FontIcons.Tests/MudBlazor.FontIcons.Tests.csproj
+      - name: Test
+        run: dotnet test test/MudBlazor.FontIcons.Tests/MudBlazor.FontIcons.Tests.csproj --configuration Release --no-restore
+
   build-pack:
     name: build-pack
     runs-on: ubuntu-latest

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,12 +20,13 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <!--
-    Shipping icon packs only. The generator is a build-time tool that produces the icon
-    classes and fonts; it targets a single TFM and is never packed, so none of the
-    multi-targeting, trimming, or package metadata below applies to it.
-  -->
-  <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('MudBlazor.FontIcons'))">
+  <!-- Identifies the two shipping icon packs; the generator and the test project are never packed. -->
+  <PropertyGroup>
+    <IsShippingIconPack>false</IsShippingIconPack>
+    <IsShippingIconPack Condition="$(MSBuildProjectName.StartsWith('MudBlazor.FontIcons')) AND !$(MSBuildProjectName.EndsWith('.Tests'))">true</IsShippingIconPack>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsShippingIconPack)' == 'true'">
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <!-- Icon constants are generated from Google's metadata and keep its naming (Filled._3d_rotation). -->
     <NoWarn>CA1707;CA1708;CA1711</NoWarn>
@@ -34,7 +35,7 @@
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('MudBlazor.FontIcons'))">
+  <PropertyGroup Condition="'$(IsShippingIconPack)' == 'true'">
     <IsPackable>true</IsPackable>
     <PackageProjectUrl>https://mudblazor.com/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/MudBlazor/MudBlazor.Icons</RepositoryUrl>
@@ -47,7 +48,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(MSBuildProjectName.StartsWith('MudBlazor.FontIcons'))">
+  <ItemGroup Condition="'$(IsShippingIconPack)' == 'true'">
     <None Include="$(MSBuildThisFileDirectory)$(PackageIcon)">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>

--- a/MudBlazor.IconPack.slnx
+++ b/MudBlazor.IconPack.slnx
@@ -2,4 +2,5 @@
   <Project Path="src/GoogleMaterialDesignIconsGenerator/GoogleMaterialDesignIconsGenerator.csproj" />
   <Project Path="src/MudBlazor.FontIcons.MaterialIcons/MudBlazor.FontIcons.MaterialIcons.csproj" />
   <Project Path="src/MudBlazor.FontIcons.MaterialSymbols/MudBlazor.FontIcons.MaterialSymbols.csproj" />
+  <Project Path="test/MudBlazor.FontIcons.Tests/MudBlazor.FontIcons.Tests.csproj" />
 </Solution>

--- a/global.json
+++ b/global.json
@@ -2,5 +2,8 @@
   "sdk": {
     "version": "10.0.100",
     "rollForward": "latestFeature"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/test/MudBlazor.FontIcons.Tests/FontFileTests.cs
+++ b/test/MudBlazor.FontIcons.Tests/FontFileTests.cs
@@ -1,0 +1,66 @@
+using System.Buffers.Binary;
+
+namespace MudBlazor.FontIcons.Tests;
+
+/// <summary>
+/// The generator downloads the fonts from Google, so a truncated or half-written response is a realistic failure.
+/// The WOFF2 header carries its own total length, which makes that cheap to detect without decoding the font.
+/// </summary>
+public class FontFileTests
+{
+    /// <summary>
+    /// "wOF2", the WOFF2 signature. See https://www.w3.org/TR/WOFF2/#woff20Header.
+    /// </summary>
+    private const uint Woff2Signature = 0x774F4632;
+
+    private const int Woff2HeaderLength = 20;
+
+    public static IEnumerable<Func<(IconPack Pack, string FontPath)>> AllFonts() =>
+        IconPack.All()
+            .Select(packFactory => packFactory())
+            .SelectMany(pack => Directory
+                .EnumerateFiles(pack.FontDirectory, "*.woff2")
+                .Order(StringComparer.Ordinal)
+                .Select(fontPath => new Func<(IconPack, string)>(() => (pack, fontPath))));
+
+    [Test]
+    [MethodDataSource(nameof(AllFonts))]
+    public async Task EveryFontStartsWithTheWoff2Signature(IconPack pack, string fontPath)
+    {
+        var header = await ReadHeaderAsync(fontPath);
+
+        await Assert.That(BinaryPrimitives.ReadUInt32BigEndian(header)).IsEqualTo(Woff2Signature);
+    }
+
+    /// <summary>
+    /// The header's length field covers the whole file, so a mismatch means the download was cut short.
+    /// </summary>
+    [Test]
+    [MethodDataSource(nameof(AllFonts))]
+    public async Task EveryFontIsTheLengthItsHeaderDeclares(IconPack pack, string fontPath)
+    {
+        var header = await ReadHeaderAsync(fontPath);
+        var declaredLength = BinaryPrimitives.ReadUInt32BigEndian(header.AsSpan(8));
+
+        await Assert.That(declaredLength).IsEqualTo((uint)new FileInfo(fontPath).Length);
+    }
+
+    [Test]
+    [MethodDataSource(nameof(AllFonts))]
+    public async Task EveryFontContainsTables(IconPack pack, string fontPath)
+    {
+        var header = await ReadHeaderAsync(fontPath);
+        var tableCount = BinaryPrimitives.ReadUInt16BigEndian(header.AsSpan(12));
+
+        await Assert.That(tableCount).IsGreaterThan((ushort)0);
+    }
+
+    private static async Task<byte[]> ReadHeaderAsync(string fontPath)
+    {
+        var header = new byte[Woff2HeaderLength];
+        await using var stream = File.OpenRead(fontPath);
+        await stream.ReadExactlyAsync(header);
+
+        return header;
+    }
+}

--- a/test/MudBlazor.FontIcons.Tests/IconConstantTests.cs
+++ b/test/MudBlazor.FontIcons.Tests/IconConstantTests.cs
@@ -1,0 +1,82 @@
+using System.Text.RegularExpressions;
+
+namespace MudBlazor.FontIcons.Tests;
+
+/// <summary>
+/// Guards the constants the generator writes from Google's metadata, so a bad refresh fails before it ships.
+/// </summary>
+public partial class IconConstantTests
+{
+    /// <summary>
+    /// Constants pair the stylesheet class with the font ligature, e.g. <c>material-symbols-outlined/rocket_launch</c>.
+    /// </summary>
+    [GeneratedRegex("^[a-z0-9-]+/[a-z0-9_]+$")]
+    private static partial Regex IconValuePattern();
+
+    [Test]
+    [MethodDataSource(typeof(IconPack), nameof(IconPack.AllIconClasses))]
+    public async Task EveryConstantHasAValue(IconPack pack, Type iconClass)
+    {
+        var empty = IconPack.ConstantsOf(iconClass)
+            .Where(constant => string.IsNullOrWhiteSpace(constant.Value))
+            .Select(constant => constant.Name)
+            .ToArray();
+
+        await Assert.That(empty).IsEmpty();
+    }
+
+    [Test]
+    [MethodDataSource(typeof(IconPack), nameof(IconPack.AllIconClasses))]
+    public async Task EveryConstantHasTheExpectedShape(IconPack pack, Type iconClass)
+    {
+        var malformed = IconPack.ConstantsOf(iconClass)
+            .Where(constant => !IconValuePattern().IsMatch(constant.Value))
+            .Select(constant => $"{constant.Name} = \"{constant.Value}\"")
+            .ToArray();
+
+        await Assert.That(malformed).IsEmpty();
+    }
+
+    /// <summary>
+    /// Each style maps to exactly one stylesheet class.
+    /// The mapping is not derivable from the type name: MaterialIcons.Rounded is material-icons-round, MaterialSymbols.Rounded is material-symbols-rounded.
+    /// </summary>
+    [Test]
+    [MethodDataSource(typeof(IconPack), nameof(IconPack.AllIconClasses))]
+    public async Task EveryIconClassUsesExactlyOneCssClass(IconPack pack, Type iconClass)
+    {
+        var cssClasses = CssClassesUsedBy(iconClass);
+
+        await Assert.That(cssClasses).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    [MethodDataSource(typeof(IconPack), nameof(IconPack.AllIconClasses))]
+    public async Task TheCssClassIsDefinedInTheStylesheet(IconPack pack, Type iconClass)
+    {
+        var declared = Stylesheet.ClassNames(await File.ReadAllTextAsync(pack.StylesheetPath));
+
+        foreach (var cssClass in CssClassesUsedBy(iconClass))
+        {
+            await Assert.That(declared).Contains(cssClass);
+        }
+    }
+
+    /// <summary>
+    /// A regeneration that fetches nothing still produces a compiling but nearly empty class.
+    /// The smallest style ships over 2,000 icons, so a four-figure floor catches that without breaking when Google retires an icon.
+    /// </summary>
+    [Test]
+    [MethodDataSource(typeof(IconPack), nameof(IconPack.AllIconClasses))]
+    public async Task EveryIconClassIsFullyPopulated(IconPack pack, Type iconClass)
+    {
+        var constants = IconPack.ConstantsOf(iconClass);
+
+        await Assert.That(constants.Count).IsGreaterThan(1_000);
+    }
+
+    private static HashSet<string> CssClassesUsedBy(Type iconClass) =>
+        IconPack.ConstantsOf(iconClass)
+            .Select(constant => constant.Value.Split('/')[0])
+            .ToHashSet(StringComparer.Ordinal);
+}

--- a/test/MudBlazor.FontIcons.Tests/IconPack.cs
+++ b/test/MudBlazor.FontIcons.Tests/IconPack.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+
+namespace MudBlazor.FontIcons.Tests;
+
+/// <summary>
+/// One shipping icon pack, and the source assets the generator produces for it.
+/// </summary>
+public sealed class IconPack(string name, params Type[] iconClasses)
+{
+    private static readonly string RepoRoot = typeof(IconPack).Assembly
+        .GetCustomAttributes<AssemblyMetadataAttribute>()
+        .Single(attribute => attribute.Key == "RepoRoot")
+        .Value ?? throw new InvalidOperationException("The RepoRoot assembly metadata is present but has no value.");
+
+    public string Name { get; } = name;
+
+    public IReadOnlyList<Type> IconClasses { get; } = iconClasses;
+
+    public string ProjectDirectory { get; } = Path.Combine(RepoRoot, "src", name);
+
+    public string StylesheetPath => Path.Combine(ProjectDirectory, "wwwroot", "css", "font.css");
+
+    public string MinifiedStylesheetPath => Path.Combine(ProjectDirectory, "wwwroot", "css", "font.min.css");
+
+    public string FontDirectory => Path.Combine(ProjectDirectory, "wwwroot", "font");
+
+    public override string ToString() => Name;
+
+    /// <summary>
+    /// The generator emits every icon as a public const string, so the constants are the literal string fields.
+    /// </summary>
+    public static IReadOnlyList<(string Name, string Value)> ConstantsOf(Type iconClass) =>
+        [.. iconClass
+            .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(field => field is { IsLiteral: true, IsInitOnly: false } && field.FieldType == typeof(string))
+            .Select(field => (field.Name, Value: field.GetRawConstantValue() as string ?? string.Empty))];
+
+    public static IEnumerable<Func<IconPack>> All() =>
+    [
+        () => new IconPack(
+            "MudBlazor.FontIcons.MaterialIcons",
+            typeof(MaterialIcons.Filled),
+            typeof(MaterialIcons.Outlined),
+            typeof(MaterialIcons.Rounded),
+            typeof(MaterialIcons.Sharp),
+            typeof(MaterialIcons.TwoTone)),
+        () => new IconPack(
+            "MudBlazor.FontIcons.MaterialSymbols",
+            typeof(MaterialSymbols.Outlined),
+            typeof(MaterialSymbols.Rounded),
+            typeof(MaterialSymbols.Sharp)),
+    ];
+
+    public static IEnumerable<Func<(IconPack Pack, Type IconClass)>> AllIconClasses() =>
+        All()
+            .Select(packFactory => packFactory())
+            .SelectMany(pack => pack.IconClasses.Select(iconClass => new Func<(IconPack, Type)>(() => (pack, iconClass))));
+}

--- a/test/MudBlazor.FontIcons.Tests/MudBlazor.FontIcons.Tests.csproj
+++ b/test/MudBlazor.FontIcons.Tests/MudBlazor.FontIcons.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <!-- Naming rules the packs already suppress, plus analyzers that do not apply to a test host. -->
+    <NoWarn>CA1707;CA1708;CA1711;CA1062;CA2007;CA1515</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" Version="1.44.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MudBlazor.FontIcons.MaterialIcons\MudBlazor.FontIcons.MaterialIcons.csproj" />
+    <ProjectReference Include="..\..\src\MudBlazor.FontIcons.MaterialSymbols\MudBlazor.FontIcons.MaterialSymbols.csproj" />
+  </ItemGroup>
+
+  <!-- The tests assert against the packs' source assets, so they need the repository root. -->
+  <ItemGroup>
+    <AssemblyMetadata Include="RepoRoot" Value="$(MSBuildThisFileDirectory)..\..\" />
+  </ItemGroup>
+
+</Project>

--- a/test/MudBlazor.FontIcons.Tests/Stylesheet.cs
+++ b/test/MudBlazor.FontIcons.Tests/Stylesheet.cs
@@ -1,0 +1,29 @@
+using System.Text.RegularExpressions;
+
+namespace MudBlazor.FontIcons.Tests;
+
+/// <summary>
+/// The parts of a generated font stylesheet the icon constants depend on.
+/// </summary>
+public static partial class Stylesheet
+{
+    /// <summary>
+    /// Class selectors at the start of a rule, e.g. <c>.material-symbols-outlined {</c>.
+    /// </summary>
+    public static IReadOnlySet<string> ClassNames(string css) =>
+        ClassSelectorPattern().Matches(css).Select(match => match.Groups[1].Value).ToHashSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Font file names referenced by <c>src: url(...)</c>, without their directory.
+    /// </summary>
+    public static IReadOnlySet<string> ReferencedFontFiles(string css) =>
+        FontUrlPattern().Matches(css)
+            .Select(match => Path.GetFileName(match.Groups[1].Value.Trim('\'', '"')))
+            .ToHashSet(StringComparer.Ordinal);
+
+    [GeneratedRegex(@"(?:^|})\s*\.([a-z0-9-]+)\s*(?:,[^{]*)?{", RegexOptions.Multiline)]
+    private static partial Regex ClassSelectorPattern();
+
+    [GeneratedRegex(@"url\(([^)]+\.woff2)\)")]
+    private static partial Regex FontUrlPattern();
+}

--- a/test/MudBlazor.FontIcons.Tests/StylesheetTests.cs
+++ b/test/MudBlazor.FontIcons.Tests/StylesheetTests.cs
@@ -1,0 +1,62 @@
+namespace MudBlazor.FontIcons.Tests;
+
+/// <summary>
+/// The stylesheet is what links a constant to a glyph, and it ships as a static web asset.
+/// A class or font that goes missing here breaks every icon in that style at runtime.
+/// </summary>
+public class StylesheetTests
+{
+    [Test]
+    [MethodDataSource(typeof(IconPack), nameof(IconPack.All))]
+    public async Task EveryReferencedFontFileExists(IconPack pack)
+    {
+        var css = await File.ReadAllTextAsync(pack.StylesheetPath);
+
+        var missing = Stylesheet.ReferencedFontFiles(css)
+            .Where(fontFile => !File.Exists(Path.Combine(pack.FontDirectory, fontFile)))
+            .ToArray();
+
+        await Assert.That(missing).IsEmpty();
+    }
+
+    /// <summary>
+    /// An orphaned font means the stylesheet stopped pointing at a file the package still ships.
+    /// </summary>
+    [Test]
+    [MethodDataSource(typeof(IconPack), nameof(IconPack.All))]
+    public async Task EveryFontFileIsReferencedByTheStylesheet(IconPack pack)
+    {
+        var css = await File.ReadAllTextAsync(pack.StylesheetPath);
+        var referenced = Stylesheet.ReferencedFontFiles(css);
+
+        var orphaned = Directory.EnumerateFiles(pack.FontDirectory, "*.woff2")
+            .Select(fontPath => Path.GetFileName(fontPath))
+            .Where(fontFile => !referenced.Contains(fontFile))
+            .ToArray();
+
+        await Assert.That(orphaned).IsEmpty();
+    }
+
+    /// <summary>
+    /// Consumers link font.min.css, so drift between the two would ship a stylesheet nothing here validates.
+    /// </summary>
+    [Test]
+    [MethodDataSource(typeof(IconPack), nameof(IconPack.All))]
+    public async Task TheMinifiedStylesheetDefinesTheSameClasses(IconPack pack)
+    {
+        var source = Stylesheet.ClassNames(await File.ReadAllTextAsync(pack.StylesheetPath));
+        var minified = Stylesheet.ClassNames(await File.ReadAllTextAsync(pack.MinifiedStylesheetPath));
+
+        await Assert.That(minified).IsEquivalentTo(source);
+    }
+
+    [Test]
+    [MethodDataSource(typeof(IconPack), nameof(IconPack.All))]
+    public async Task TheMinifiedStylesheetReferencesTheSameFonts(IconPack pack)
+    {
+        var source = Stylesheet.ReferencedFontFiles(await File.ReadAllTextAsync(pack.StylesheetPath));
+        var minified = Stylesheet.ReferencedFontFiles(await File.ReadAllTextAsync(pack.MinifiedStylesheetPath));
+
+        await Assert.That(minified).IsEquivalentTo(source);
+    }
+}


### PR DESCRIPTION
The packs are regenerated from Google's metadata on a schedule and nothing checked the output, so a bad refresh could reach NuGet unnoticed. This adds 72 tests over the generated constants, the stylesheets, and the font binaries.

## What is covered

**Constants** — every value is present and matches the `class/ligature` shape; each style maps to exactly one stylesheet class, and that class is actually defined in `font.css`; each style stays fully populated, so a regeneration that fetched nothing fails instead of compiling.

The one-class-per-style check earns its keep because the mapping is not derivable from the type name: `MaterialIcons.Rounded` is `material-icons-round`, but `MaterialSymbols.Rounded` is `material-symbols-rounded`.

**Stylesheets** — every `src: url(...)` resolves to a file that exists, no font is orphaned, and `font.min.css` declares the same classes and fonts as `font.css`. Consumers link the minified file, so drift between the two would ship a stylesheet nothing validates.

**Fonts** — every woff2 starts with the `wOF2` signature, matches the length its own header declares, and reports at least one table. The generator downloads these from Google, so a truncated response is the realistic failure, and the header makes it detectable without decoding the font.

## Verified by mutation

A green suite proves nothing on its own, so I broke two things deliberately and confirmed the right tests failed:

| Mutation | Failed |
| :-- | :-- |
| Truncated `MaterialIcons.woff2` by 500 bytes | `EveryFontIsTheLengthItsHeaderDeclares` |
| Renamed `.material-symbols-sharp` in `font.css` | `TheCssClassIsDefinedInTheStylesheet`, `TheMinifiedStylesheetDefinesTheSameClasses` |

Both assets were restored afterwards; the suite is green on unmodified sources.

## Notes

- `TUnit` is the only package reference. `dotnet test` on the .NET 10 SDK needs the Microsoft.Testing.Platform opt-in, which goes in `global.json` — the SDK gates it on a `_SupportsGlobalJsonTestRunner` check, and the older `TestingPlatformDotnetTestSupport` property has no effect there.
- `Directory.Build.props` gained an `IsShippingIconPack` property. The previous `StartsWith('MudBlazor.FontIcons')` condition would otherwise have handed the test project multi-targeting, trimming, and package metadata.
- Renovate now groups `test/**` NuGet updates as "test dependencies" with automerge.
- A `test` job runs on every push and pull request. Once #47 lands and the quarterly refresh arrives as a pull request, these tests gate it.